### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/D6OnHelpFix.pas
+++ b/D6OnHelpFix.pas
@@ -50,7 +50,7 @@ unit D6OnHelpFix;
 ABout the D6 OnHelp bug:
 
   Delphi6 does not pass on all help calls to the OnHelp event.
-  Infact if you search for WMHelp code in Forms.pas you will see that
+  In fact if you search for WMHelp code in Forms.pas you will see that
   only Application.InvokeHelp() handles FOnHelp. And that it only works
   if the (biHelp in BorderIcons) property is true. 
 
@@ -91,7 +91,7 @@ Mini Tutorial:
   Thus typically you might do this
   a) call WinHelpTester_Enable(false)
   b) Make your WinHelp calls
-  c) call WinHelpTester_Enable(true) to reenable our OnHelp fix again.
+  c) call WinHelpTester_Enable(true) to re-enable our OnHelp fix again.
 
   == IHelpSelector
 
@@ -112,7 +112,7 @@ Mini Tutorial:
   viewer 1's UnderstandsTopic() and UnderstandsContext() so that they return
   false letting viewer 2 get a go.
 
-  Thats the end of the quick tour. Study HelpIntfs.pas (HelpManager),
+  That's the end of the quick tour. Study HelpIntfs.pas (HelpManager),
   WinHelpViewer.pas (Viewer 1 code) and D6OnHelp.pas (our viewer 2 code)
   to learn more about how it all works. Also read the online help.
 
@@ -252,7 +252,7 @@ begin
   Result := 0;      //return index of first item in supplied keyword list
 end;
 
-{Returning our name poistion in the provided list will ensure that we are used to display the TOC}
+{Returning our name position in the provided list will ensure that we are used to display the TOC}
 function THelpSelector.TableOfContents(Contents: TStrings): Integer;
 var I: Integer;
 begin

--- a/MTRandom.pas
+++ b/MTRandom.pas
@@ -74,7 +74,7 @@ interface
   array. SHA-1 is called secure because it is computationally infeasible to
   find a message corresponding to a given message digest or to find a second
   (different) message which produces the same message digest. SHA-1 is used
-  to noninvertible convertion of the output of MT random number generator in
+  to noninvertible conversion of the output of MT random number generator in
   MT_SecureRandNext function (each fifty-five bytes from the random generator
   are replaced with twenty bytes of their secure hash).
 
@@ -99,7 +99,7 @@ type
 
 { MT_RandInit initialize the random number generator. Identificator of this
   generator is returned in ID parameter. It is used as the first parameter
-  at calling of all ather subsequent routines. For initialization you need to
+  at calling of all other subsequent routines. For initialization you need to
   pass into MT_RandInit some Seed value or the initial vector InitVector.
   The ID identificator must be destroyed by MT_RandDone at the end of work
   with this random generator. }
@@ -178,7 +178,7 @@ procedure MT_SecureRandFill(ID: TMTID; P: Pointer; L: Cardinal);
 procedure MT_SecureRandXOR(ID: TMTID; P: Pointer; L: Cardinal);
 
 { MT_RandDone releases all memory resources which is occupied by the random
-  number generator identified by ID. After that you cann't pass this ID into
+  number generator identified by ID. After that you can't pass this ID into
   any functions. }
 
 procedure MT_RandDone(ID: TMTID);
@@ -196,7 +196,7 @@ function MT_TimeStamp: Int64;
 { Q_CAST6SelfTest checks the CAST6-256 algorithm implementation by test
   vectors from RFC 2612. If this test passed successfully the function returns
   True else it returns False. The single specific feature of this CAST-256
-  implementation is an inverse byte-ordering (endianess). This feature
+  implementation is an inverse byte-ordering (endianness). This feature
   is not affected on security but some improve performance of the algorithm
   on PC-platform. }
 
@@ -319,7 +319,7 @@ end;
 
 function MT_CodesToStr(const S: string): string;
 const
-  Msg: string = 'Error during convertion string of hexadecimal codes into the string of characters';
+  Msg: string = 'Error during conversion string of hexadecimal codes into the string of characters';
 asm
         TEST    EAX,EAX
         JE      @@cl

--- a/OptSearch.pas
+++ b/OptSearch.pas
@@ -82,7 +82,7 @@ begin
   else if Pos('Status',f.optManeuver)>0 then f.optManeuver:='Status: Not running';
   Form1.OutPut.Invalidate;
   f.running:=false; //stop
-  idaOldU.free;//doesnt matter if nil
+  idaOldU.free; //does not matter if nil
 
   if Form1.FreeThreadsonTerminate1.Checked then idaU:=nil;/////////////////
 

--- a/Options.pas
+++ b/Options.pas
@@ -46,7 +46,7 @@ begin
 end;
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-//+++++++++++++++Enter Stop Lenght++++++++++++++++++++++++++++++++++++++++++++++
+//+++++++++++++++Enter Stop Length++++++++++++++++++++++++++++++++++++++++++++++
 procedure TOptionForm.RBStopAtClick(Sender: TObject);
 begin
    stopAt:=(Sender as TRadioButton).Tag;

--- a/UKeyboardOutput.pas
+++ b/UKeyboardOutput.pas
@@ -475,7 +475,7 @@ end; { procedure }
 {|~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  | SendKeyAsc
  | Desc:  Output a single down or release Virtual Keystroke using an ascii
- |        code equivilent, with the Windows API SendInput function:
+ |        code equivalent, with the Windows API SendInput function:
  |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~}
 procedure SendKeyAsc(AsciiKey: SmallInt; booDown: boolean);
 begin
@@ -928,7 +928,7 @@ begin
   GetAEKey := GetAsyncKeyState(Integer(KeyPressed)) <> 0;
 end; { function }
 
-// Return the Virual Key Equivalent for a ASCII Key
+// Return the Virtual Key Equivalent for a ASCII Key
 
 function GetAscVirtualKey(AKey: byte): ShortInt;
 begin

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,7 @@ Version History:
 2008-12-26  Cube Explorer 4.63
             -The autorun feature of Cube Explorer for solving many cubes takes
              advantage of machines with more than one processor (phyical or virtual).
-             With a Core i7 920 CPU (8 physical and virutal processors) and the 4.63s
+             With a Core i7 920 CPU (8 physical and virtual processors) and the 4.63s
              version about 490 cubes are solved optimally per hour.
 
 2008-09-25  Cube Explorer 4.62
@@ -108,7 +108,7 @@ Version History:
             -Edit|Arrange Selected Symmetric Cubes and Edit|Add Symmetry Info for Selected Cubes
              did not work correctly for twisted center facelets.
             -Some changes ins Search routine of Two-Phase-Algorithm for cubes with twisted centers
-             improves perfomance.
+             improves performance.
             -WCA scramble menu simplified  
 
 2008-08-12  Cube Explorer 4.50
@@ -307,7 +307,7 @@ Version History:
            -disabled some forgotten debugging code
 
 2004-03-27 Cube Explorer 3.16
-           -improved error handling in online cube-solver modul. Seems to run stable now.
+           -improved error handling in online cube-solver module. Seems to run stable now.
            -Option settings are saved in cube.ini now.
 
 2004-03-21 Cube Explorer 3.15


### PR DESCRIPTION
[`codespell --ignore-words-list=ba,ist,oll`](https://pypi.org/project/codespell/)